### PR TITLE
Fix File > Open menu, local link navigation, and URL encoding for links with spaces

### DIFF
--- a/QuickMD/CHANGELOG.md
+++ b/QuickMD/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to QuickMD will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.2] - 2026-02-24
+
+### Added
+- **Local Markdown Navigation:** Clicking a link to another local `.md`, `.markdown`, `.mdown`, or `.mkd` file from within a document now automatically opens the target file inside a new QuickMD window, bypassing default system editors.
+- **Space Character URL Parsing:** Proper percent-encoding is now explicitly layered into the MarkdownRenderer, fixing a bug where links with spaces in their paths/titles would fail to parse or activate.
+
+### Fixed
+- **Missing File -> Open Menu:** Restored the native `File -> Open` and `File -> Open Recent` macOS menu items that were previously hidden/replaced by an empty CommandGroup.
+- **Local Document Routing:** Fixed the routing layer for relative document links (`./other.md`); these are now resolved dynamically against the originating document's directory.
+
 ## [1.3.1] - 2026-02-13
 
 ### Added

--- a/QuickMD/QuickMD/MarkdownRenderer.swift
+++ b/QuickMD/QuickMD/MarkdownRenderer.swift
@@ -374,7 +374,11 @@ struct MarkdownRenderer: Sendable {
         attr.font = .system(size: 14)
         attr.foregroundColor = theme.linkColor
         attr.underlineStyle = .single
+        
         if let parsedUrl = URL(string: url) {
+            attr.link = parsedUrl
+        } else if let encoded = url.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
+                  let parsedUrl = URL(string: encoded) {
             attr.link = parsedUrl
         }
         return (attr, remaining)

--- a/QuickMD/QuickMD/QuickMDApp.swift
+++ b/QuickMD/QuickMD/QuickMDApp.swift
@@ -17,7 +17,6 @@ struct QuickMDApp: App {
             MarkdownView(document: file.document, documentURL: file.fileURL)
         }
         .commands {
-            CommandGroup(replacing: .newItem) { }
             CommandGroup(replacing: .saveItem) { }
             CommandGroup(after: .saveItem) {
                 Divider()


### PR DESCRIPTION
While using QuickMD I ran into a few issues with file handling and link navigation.

## Changes

### Restored File > Open menu
`CommandGroup(replacing: .newItem) { }` was replacing the entire newItem group, which
includes Open and Open Recent. Removed that line — Save is still replaced as intended.

### Local .md links now open in QuickMD
Clicking a relative link like `[notes](./notes.md)` was failing with error -50 because
the URL wasn't being resolved against the current document's directory.

Added `handleLinkActivation()` in MarkdownView that:
- Opens http/https links in the default browser
- Resolves relative paths against the current document's directory
- Forces .md/.markdown/.mdown/.mkd files to open in QuickMD via
  `NSWorkspace.open(_:withApplicationAt:)`
- Hands off other file types to their default app

### URL encoding fallback for links with spaces
Links like `[doc](my file.md)` failed to parse because `URL(string:)` rejects spaces.
Now tries parsing the URL as-is first, falls back to percent-encoding only if that fails.

## Known limitation

Local images referenced from markdown (e.g. `![](screenshot.png)`) won't render in
sandboxed builds because the app only has read access to the file the user explicitly
opened, not sibling files in the same directory. The recommended fix is
Security-Scoped Bookmarks — prompting via NSOpenPanel for folder access and persisting
it. Left out of this PR since it touches security policy and App Store review
considerations. Happy to submit a follow-up PR if interested.

## Files changed
- `QuickMDApp.swift` — removed the line hiding File > Open
- `MarkdownView.swift` — added link interception + routing logic
- `MarkdownRenderer.swift` — URL parse-first, encode-as-fallback
- `CHANGELOG.md` — added 1.3.2 entry