### PR TITLE
fix: Recent Documents sidebar can be closed from its header

### DIFF
--- a/QuickMD/CHANGELOG.md
+++ b/QuickMD/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to QuickMD will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Recent Documents sidebar had no in-panel way to close it; the Documents header now has a collapse control (⇧⌘D still toggles).
+
 ## [1.9.0] - 2026-08-17
 
 A "native layout" release: the document body was rebuilt on an AppKit-backed virtualized list with exact, pre-measured heights, which retires the last SwiftUI lazy-stack estimation and makes scrolling, jumping and reading-position preservation exact for every document size. On top of that: Reading Mode, definition lists, a zoom indicator, typeset math in PDF/print, and the hover-pill fix contributed by [@Coriou](https://github.com/Coriou) (#20). Thank you!

--- a/QuickMD/QuickMD/MarkdownView.swift
+++ b/QuickMD/QuickMD/MarkdownView.swift
@@ -205,9 +205,11 @@ struct MarkdownView: View {
             // sidebars at the USE SITE — their @AppStorage flags keep whatever the
             // reader chose, so leaving reading mode brings back exactly that.
             if isDocumentListVisible && !isReadingMode {
-                RecentDocumentsSidebar(theme: theme, currentURL: documentURL)
-                    .frame(width: documentListWidth)
-                    .transition(.move(edge: .leading).combined(with: .opacity))
+                RecentDocumentsSidebar(theme: theme, currentURL: documentURL) {
+                    withAnimation(.easeInOut(duration: 0.2)) { isDocumentListVisible = false }
+                }
+                .frame(width: documentListWidth)
+                .transition(.move(edge: .leading).combined(with: .opacity))
                 SidebarResizeHandle(width: $documentListWidth, minWidth: 160, maxWidth: 500)
             }
 

--- a/QuickMD/QuickMD/Views/RecentDocumentsSidebar.swift
+++ b/QuickMD/QuickMD/Views/RecentDocumentsSidebar.swift
@@ -11,6 +11,7 @@ struct RecentDocumentsSidebar: View {
     @ObservedObject var store: RecentDocumentsStore = .shared
     let theme: MarkdownTheme
     let currentURL: URL?
+    let onCollapse: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -22,6 +23,19 @@ struct RecentDocumentsSidebar: View {
                     .font(.system(size: 12, weight: .semibold))
                     .foregroundColor(.secondary)
                 Spacer()
+                // Same symbol as the overlay capsule; inverse verb. Not xmark — that's row-remove.
+                Button {
+                    onCollapse()
+                } label: {
+                    Image(systemName: "sidebar.leading")
+                        .font(.system(size: 11))
+                        .foregroundColor(.secondary)
+                        .padding(3)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .help("Hide recent documents (⇧⌘D)")
+                .accessibilityLabel("Hide recent documents")
                 if !store.documents.isEmpty {
                     Button {
                         store.clear()


### PR DESCRIPTION
Me again with a half-baked, visually untested PR.

Once the Recent Documents sidebar is open, there is no in-panel way to close it. Shift-Cmd-D still toggles it; this just adds a collapse control on the Documents header (same icon as the floating capsule, inverse verb).

Still no Xcode on this machine, so I have not seen it run. The button clones the existing trash control. MarkdownView still owns the flag.

Two more PRs coming on the same theme:
- the same collapse control on the Table of Contents header
- moving Table of Contents and Recent Documents from Edit to View

If you can't be bothered to clean up after me, I'll take care of it when I get home.