### PR TITLE
fix: Table of Contents sidebar can be closed from its header

### DIFF
--- a/QuickMD/CHANGELOG.md
+++ b/QuickMD/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to QuickMD will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Table of Contents sidebar had no in-panel way to close it; the Contents header now has a collapse control (⇧⌘T still toggles).
+
 ## [1.9.0] - 2026-08-17
 
 A "native layout" release: the document body was rebuilt on an AppKit-backed virtualized list with exact, pre-measured heights, which retires the last SwiftUI lazy-stack estimation and makes scrolling, jumping and reading-position preservation exact for every document size. On top of that: Reading Mode, definition lists, a zoom indicator, typeset math in PDF/print, and the hover-pill fix contributed by [@Coriou](https://github.com/Coriou) (#20). Thank you!

--- a/QuickMD/QuickMD/MarkdownView.swift
+++ b/QuickMD/QuickMD/MarkdownView.swift
@@ -223,6 +223,8 @@ struct MarkdownView: View {
                     if let section = SectionExtractor.extractSection(from: currentText, entry: entry, headings: headings) {
                         copyToClipboard(section)
                     }
+                }, onCollapse: {
+                    withAnimation(.easeInOut(duration: 0.2)) { isToCVisible = false }
                 })
                 .frame(width: 220)
                 Divider()

--- a/QuickMD/QuickMD/Views/TableOfContentsView.swift
+++ b/QuickMD/QuickMD/Views/TableOfContentsView.swift
@@ -8,6 +8,7 @@ struct TableOfContentsView: View {
     let headings: [ToCEntry]
     let onSelect: (String) -> Void
     var onCopy: ((ToCEntry) -> Void)? = nil
+    let onCollapse: () -> Void
     @Environment(\.colorScheme) private var colorScheme
     @AppStorage("selectedTheme") private var selectedThemeName: String = "Auto"
 
@@ -18,13 +19,27 @@ struct TableOfContentsView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             // Header
-            HStack {
+            HStack(spacing: 6) {
                 Image(systemName: "list.bullet.indent")
                     .font(.system(size: 12))
                     .foregroundColor(.secondary)
                 Text("Contents")
                     .font(.system(size: 12, weight: .semibold))
                     .foregroundColor(.secondary)
+                Spacer()
+                // Hide-sidebar language (same as Documents). Not doc.on.doc — that's row copy.
+                Button {
+                    onCollapse()
+                } label: {
+                    Image(systemName: "sidebar.leading")
+                        .font(.system(size: 11))
+                        .foregroundColor(.secondary)
+                        .padding(3)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .help("Hide table of contents (⇧⌘T)")
+                .accessibilityLabel("Hide table of contents")
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 8)


### PR DESCRIPTION
Same as Documents: once the ToC is open, there's no in-panel way to close it.

Shift-Cmd-T still toggles; this just adds a collapse control on the Contents header (same hide-sidebar icon as Documents). MarkdownView still owns the flag. No overlay capsule — ToC never had one.