### PR TITLE
ui: move Table of Contents and Recent Documents to the View menu

### DIFF
--- a/QuickMD/CHANGELOG.md
+++ b/QuickMD/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to QuickMD will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Table of Contents and Recent Documents moved from the Edit menu to View (shortcuts unchanged).
+
 ## [1.9.0] - 2026-08-17
 
 A "native layout" release: the document body was rebuilt on an AppKit-backed virtualized list with exact, pre-measured heights, which retires the last SwiftUI lazy-stack estimation and makes scrolling, jumping and reading-position preservation exact for every document size. On top of that: Reading Mode, definition lists, a zoom indicator, typeset math in PDF/print, and the hover-pill fix contributed by [@Coriou](https://github.com/Coriou) (#20). Thank you!

--- a/QuickMD/QuickMD/QuickMDApp.swift
+++ b/QuickMD/QuickMD/QuickMDApp.swift
@@ -40,13 +40,13 @@ struct QuickMDApp: App {
             }
             CommandGroup(replacing: .textEditing) {
                 FindMenuCommand()
-                ToggleToCCommand()
-                ToggleDocumentListCommand()
                 Divider()
                 CopyMarkdownCommand()
             }
             CommandGroup(after: .toolbar) {
                 ZoomCommands()
+                ToggleToCCommand()
+                ToggleDocumentListCommand()
                 ReadingModeCommand()
             }
             CommandGroup(replacing: .help) {


### PR DESCRIPTION
Table of Contents and Recent Documents were in Edit only because they got stuffed into the textEditing command group next to Find.

Moved them to View, after Zoom and before Reading Mode. Shortcuts and the reading-mode disable are unchanged. Find and Copy Markdown stay in Edit.