### PR TITLE
fix: update deprecated Cask macOS dependency syntax

### DIFF
--- a/Casks/quickmd.rb
+++ b/Casks/quickmd.rb
@@ -13,7 +13,7 @@ cask "quickmd" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   app "QuickMD.app"
 


### PR DESCRIPTION
This PR fixes #25.

https://github.com/Homebrew/brew/issues/22620#issuecomment-4659445289, commented 2026-06-09:
> In ~3 months these warnings turn into errors and all these packages will be broken. If we let people hide them: they will not get reported nor fixed.

I don't know the exact brew schedule, but based on that comment this would give us roughly until the 9th September.

Related PR in the dedicated cask repo: https://github.com/b451c/homebrew-quickmd/pull/3