### PR TITLE
Renderer: align ordered list items on the widest marker of their list

### DIFF
--- a/QuickMD/QuickMD/MarkdownRenderer.swift
+++ b/QuickMD/QuickMD/MarkdownRenderer.swift
@@ -111,12 +111,50 @@ struct MarkdownRenderer: Sendable {
     func render(_ markdown: String) -> AttributedString {
         var result = AttributedString()
 
-        for line in Self.joinSoftBreaks(markdown.components(separatedBy: "\n")) {
-            result.append(renderLine(line))
+        let lines = Self.joinSoftBreaks(markdown.components(separatedBy: "\n"))
+        // The hanging indent of an ordered item must be the width of the WIDEST
+        // marker in its list, not of its own: the body font is not monospaced,
+        // so "1. " and "10. " have different widths and each item's text would
+        // start at a different x. The run is known before any rendering, so the
+        // widest prefix is too.
+        let hangs = Self.widestOrderedPrefixes(lines)
+        for (index, line) in lines.enumerated() {
+            result.append(renderLine(line, hangingPrefix: hangs[index]))
             result.append(AttributedString("\n"))
         }
 
         return result
+    }
+
+    /// For every line, the widest ordered-list prefix of the contiguous run it
+    /// belongs to — `nil` for lines that are not ordered items.
+    ///
+    /// A run ends at the first line that is not an ordered item at the same
+    /// indent level, which is what a reader sees as one list.
+    static func widestOrderedPrefixes(_ lines: [String]) -> [String?] {
+        var out = [String?](repeating: nil, count: lines.count)
+        var start = 0
+        while start < lines.count {
+            guard let first = orderedItem(lines[start]) else { start += 1; continue }
+            var end = start, widest = first.prefix
+            while end + 1 < lines.count,
+                  let next = orderedItem(lines[end + 1]), next.level == first.level {
+                end += 1
+                if next.prefix.count > widest.count { widest = next.prefix }
+            }
+            for i in start...end { out[i] = widest }
+            start = end + 1
+        }
+        return out
+    }
+
+    /// `(prefix, level)` of an ordered list item, prefix including its indent.
+    private static func orderedItem(_ line: String) -> (prefix: String, level: Int)? {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard trimmed.range(of: #"^(\d+)\.\s"#, options: .regularExpression) != nil else { return nil }
+        let indent = line.prefix(while: { $0 == " " || $0 == "\t" })
+        let number = trimmed.prefix(while: { $0.isNumber })
+        return (indentSpaces(listLevel(for: indent)) + "\(number). ", listLevel(for: indent))
     }
 
     // MARK: - Soft Breaks
@@ -192,7 +230,7 @@ struct MarkdownRenderer: Sendable {
 
     // MARK: - Line Rendering
 
-    private func renderLine(_ line: String) -> AttributedString {
+    private func renderLine(_ line: String, hangingPrefix: String? = nil) -> AttributedString {
         let trimmed = line.trimmingCharacters(in: .whitespaces)
 
         // Header - extract hash count from regex group, not space position
@@ -227,7 +265,8 @@ struct MarkdownRenderer: Sendable {
             let level = Self.listLevel(for: line.prefix(while: { $0 == " " || $0 == "\t" }))
             let number = Int(trimmed.prefix(while: { $0.isNumber })) ?? 1
             let content = String(trimmed[match.upperBound...])
-            return renderListItem(content, level: level, ordered: true, number: number)
+            return renderListItem(content, level: level, ordered: true, number: number,
+                                  hangingPrefix: hangingPrefix)
         }
 
         // Empty line
@@ -312,13 +351,15 @@ struct MarkdownRenderer: Sendable {
         return min(columns / 2, 8)
     }
 
-    private func renderListItem(_ text: String, level: Int, ordered: Bool, number: Int) -> AttributedString {
+    private func renderListItem(_ text: String, level: Int, ordered: Bool, number: Int,
+                                hangingPrefix: String? = nil) -> AttributedString {
         let prefix = Self.indentSpaces(level) + (ordered ? "\(number). " : "• ")
         var attr = AttributedString(prefix)
         attr.setDualFont(size: scaled(14), fonts: theme.fonts)
         attr.setDualForeground(theme.textColor)
         attr.append(renderInlineFormatting(text))
-        applyListParagraphStyle(&attr, hangingUnder: prefix)
+        // Hang under the widest prefix of the list, not under this item's own.
+        applyListParagraphStyle(&attr, hangingUnder: hangingPrefix ?? prefix)
         return attr
     }
 

--- a/QuickMD/QuickMDTests/RendererTests.swift
+++ b/QuickMD/QuickMDTests/RendererTests.swift
@@ -115,6 +115,28 @@ final class RendererTests: XCTestCase {
         }
     }
 
+    /// Every paragraph style in `markdown`, in document order.
+    private func listStyles(_ markdown: String) throws -> [NSParagraphStyle] {
+        let r = MarkdownRenderer(theme: MarkdownTheme.cached(for: .light), fontScale: 1)
+        let ns = try NSAttributedString(r.render(markdown), including: \.appKit)
+        var out: [NSParagraphStyle] = []
+        ns.enumerateAttribute(.paragraphStyle, in: NSRange(location: 0, length: ns.length)) { v, _, _ in
+            if let style = v as? NSParagraphStyle { out.append(style) }
+        }
+        return out
+    }
+
+    /// The items of ONE list must share a hanging indent, or their text starts
+    /// at a different x. The body font is not monospaced, so "1. " and "10. "
+    /// are 18.47 pt and 31.00 pt wide at a 21 pt body — a 12.5 pt step, visible
+    /// at a glance on any list that crosses ten items.
+    func testOrderedItemsOfOneListShareTheirHangingIndent() throws {
+        let markdown = (1...12).map { "\($0). alpha" }.joined(separator: "\n")
+        let indents = Set(try listStyles(markdown).map { $0.headIndent })
+        XCTAssertEqual(indents.count, 1,
+                       "items of one list hang at \(indents.sorted()) instead of sharing one indent")
+    }
+
     /// A wider marker has to hang further, or "10." would overlap its own text.
     func testWiderOrderedMarkerHangsFurther() throws {
         let single = try listStyle("1. alpha")


### PR DESCRIPTION
<head></head><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; box-sizing: border-box; margin-bottom: 16px; caret-color: rgb(36, 41, 46); color: rgb(36, 41, 46); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; margin-top: 0px !important;">Ordered list items each hang under their own marker, so their text starts at a different x. This aligns every item of a list on the widest marker of that list.</p><h2 id="the-problem" style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-weight: 600; line-height: 1.25; padding-bottom: 0.3rem; border-bottom: 1px solid var(--header-bottom-border); font-size: 1.5rem; caret-color: rgb(36, 41, 46); color: rgb(36, 41, 46); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;;">The problem</h2><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; caret-color: rgb(36, 41, 46); color: rgb(36, 41, 46); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;;"><code style="box-sizing: border-box; font-size: 13.6px; font-family: var(--code-font); padding: 0.2rem 0.4rem; margin: 0px; background-color: var(--code-background); border-radius: 6px;">renderListItem</code><span class="Apple-converted-space"> </span>calls<span class="Apple-converted-space"> </span><code style="box-sizing: border-box; font-size: 13.6px; font-family: var(--code-font); padding: 0.2rem 0.4rem; margin: 0px; background-color: var(--code-background); border-radius: 6px;">applyListParagraphStyle(_:hangingUnder:)</code><span class="Apple-converted-space"> </span>with that item’s own prefix, which delegates to<span class="Apple-converted-space"> </span><code style="box-sizing: border-box; font-size: 13.6px; font-family: var(--code-font); padding: 0.2rem 0.4rem; margin: 0px; background-color: var(--code-background); border-radius: 6px;">applyHangingIndent(_:indent:hangingUnder:)</code>:</p><pre class="hl" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; box-sizing: border-box; max-width: 902px; touch-action: pan-x; font-size: 13.6px; font-family: var(--code-font); background-color: var(--hl_Background); margin-top: 0px; margin-bottom: 16px; overflow-wrap: normal; padding: 16px; overflow: auto; line-height: 1.45; border-radius: 6px; caret-color: rgb(36, 41, 46); color: rgb(36, 41, 46);"><code class="language-swift" style="box-sizing: border-box; font-size: 13.6px; font-family: var(--code-font); padding: 0px; margin: 0px; background-color: initial; border-radius: 6px; word-break: normal; white-space: pre; background-image: none; background-position: 0% 0%; background-size: auto; background-repeat: repeat; background-attachment: scroll; background-origin: padding-box; background-clip: border-box; border: 0px; display: inline; overflow: visible; line-height: inherit; overflow-wrap: normal;">style<span class="hl opt" style="box-sizing: border-box; color: var(--hl_Operator); font-weight: normal;">.</span>firstLineHeadIndent <span class="hl opt" style="box-sizing: border-box; color: var(--hl_Operator); font-weight: normal;">=</span> indent
style<span class="hl opt" style="box-sizing: border-box; color: var(--hl_Operator); font-weight: normal;">.</span>headIndent <span class="hl opt" style="box-sizing: border-box; color: var(--hl_Operator); font-weight: normal;">=</span> indent <span class="hl opt" style="box-sizing: border-box; color: var(--hl_Operator); font-weight: normal;">+</span> <span class="hl kwd" style="box-sizing: border-box; color: var(--hl_Keyword-4); font-weight: normal;">width</span><span class="hl opt" style="box-sizing: border-box; color: var(--hl_Operator); font-weight: normal;">(</span>of<span class="hl opt" style="box-sizing: border-box; color: var(--hl_Operator); font-weight: normal;">:</span> prefix<span class="hl opt" style="box-sizing: border-box; color: var(--hl_Operator); font-weight: normal;">)</span>
</code></pre><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; caret-color: rgb(36, 41, 46); color: rgb(36, 41, 46); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;;">The body font is not monospaced, so prefixes of different items have different widths. Measured at a 21 pt body:</p>
prefix | width | vs "1. "
-- | -- | --
"1. " | 18.47 pt | —
"9. " | 21.95 pt | +3.49
"10. " | 31.00 pt | +12.53
"100. " | 43.68 pt | +25.21

<p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; caret-color: rgb(36, 41, 46); color: rgb(36, 41, 46); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;;">A ten-item list is enough to see it: the text of item 10 starts 12.53 pt further right than that of item 1. Nothing overflows — no width is imposed — but nothing lines up either.</p><h2 id="the-change" style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-weight: 600; line-height: 1.25; padding-bottom: 0.3rem; border-bottom: 1px solid var(--header-bottom-border); font-size: 1.5rem; caret-color: rgb(36, 41, 46); color: rgb(36, 41, 46); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;;">The change</h2><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; caret-color: rgb(36, 41, 46); color: rgb(36, 41, 46); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;;"><code style="box-sizing: border-box; font-size: 13.6px; font-family: var(--code-font); padding: 0.2rem 0.4rem; margin: 0px; background-color: var(--code-background); border-radius: 6px;">render</code><span class="Apple-converted-space"> </span>pre-scans the joined lines and, for each contiguous run of ordered items at one indent level, computes the widest prefix; every item of the run hangs under it. The run is fully known before any item is rendered, so the widest prefix is too.</p><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; caret-color: rgb(36, 41, 46); color: rgb(36, 41, 46); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;;"><code style="box-sizing: border-box; font-size: 13.6px; font-family: var(--code-font); padding: 0.2rem 0.4rem; margin: 0px; background-color: var(--code-background); border-radius: 6px;">renderLine</code><span class="Apple-converted-space"> </span>and<span class="Apple-converted-space"> </span><code style="box-sizing: border-box; font-size: 13.6px; font-family: var(--code-font); padding: 0.2rem 0.4rem; margin: 0px; background-color: var(--code-background); border-radius: 6px;">renderListItem</code><span class="Apple-converted-space"> </span>take it as an optional parameter defaulting to<span class="Apple-converted-space"> </span><code style="box-sizing: border-box; font-size: 13.6px; font-family: var(--code-font); padding: 0.2rem 0.4rem; margin: 0px; background-color: var(--code-background); border-radius: 6px;">nil</code>, so unordered items, task items and every other caller are untouched.</p><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; caret-color: rgb(36, 41, 46); color: rgb(36, 41, 46); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;;">Two files, 69 insertions, 6 deletions.</p><h2 id="tests" style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-weight: 600; line-height: 1.25; padding-bottom: 0.3rem; border-bottom: 1px solid var(--header-bottom-border); font-size: 1.5rem; caret-color: rgb(36, 41, 46); color: rgb(36, 41, 46); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;;">Tests</h2><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; caret-color: rgb(36, 41, 46); color: rgb(36, 41, 46); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;;"><code style="box-sizing: border-box; font-size: 13.6px; font-family: var(--code-font); padding: 0.2rem 0.4rem; margin: 0px; background-color: var(--code-background); border-radius: 6px;">testOrderedItemsOfOneListShareTheirHangingIndent</code><span class="Apple-converted-space"> </span>is added. It renders a twelve-item list and asserts that all items share one<span class="Apple-converted-space"> </span><code style="box-sizing: border-box; font-size: 13.6px; font-family: var(--code-font); padding: 0.2rem 0.4rem; margin: 0px; background-color: var(--code-background); border-radius: 6px;">headIndent</code>. It<span class="Apple-converted-space"> </span><strong style="box-sizing: border-box;">fails on unpatched main and passes with this change</strong>. The full suite passes.</p><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; caret-color: rgb(36, 41, 46); color: rgb(36, 41, 46); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;;"><code style="box-sizing: border-box; font-size: 13.6px; font-family: var(--code-font); padding: 0.2rem 0.4rem; margin: 0px; background-color: var(--code-background); border-radius: 6px;">testWiderOrderedMarkerHangsFurther</code><span class="Apple-converted-space"> </span>keeps passing, and for the right reason: it renders<span class="Apple-converted-space"> </span><code style="box-sizing: border-box; font-size: 13.6px; font-family: var(--code-font); padding: 0.2rem 0.4rem; margin: 0px; background-color: var(--code-background); border-radius: 6px;">"1. alpha"</code><span class="Apple-converted-space"> </span>and<span class="Apple-converted-space"> </span><code style="box-sizing: border-box; font-size: 13.6px; font-family: var(--code-font); padding: 0.2rem 0.4rem; margin: 0px; background-color: var(--code-background); border-radius: 6px;">"10. alpha"</code><span class="Apple-converted-space"> </span>as two separate one-item documents, so each still hangs under its own — and only — marker. Its stated intent,<span class="Apple-converted-space"> </span><em style="box-sizing: border-box;">“a wider marker has to hang further, or<span class="Apple-converted-space"> </span><code style="box-sizing: border-box; font-size: 13.6px; font-family: var(--code-font); padding: 0.2rem 0.4rem; margin: 0px; background-color: var(--code-background); border-radius: 6px;">10.</code><span class="Apple-converted-space"> </span>would overlap its own text”</em>, is preserved: within a list, every item now hangs under the widest one, so the widest never overlaps its text.</p><h2 id="notes" style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-weight: 600; line-height: 1.25; padding-bottom: 0.3rem; border-bottom: 1px solid var(--header-bottom-border); font-size: 1.5rem; caret-color: rgb(36, 41, 46); color: rgb(36, 41, 46); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;;">Notes</h2><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; caret-color: rgb(36, 41, 46); color: rgb(36, 41, 46); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;;">Verified against<span class="Apple-converted-space"> </span><code style="box-sizing: border-box; font-size: 13.6px; font-family: var(--code-font); padding: 0.2rem 0.4rem; margin: 0px; background-color: var(--code-background); border-radius: 6px;">28d86fd</code>. Built and tested with:</p><pre class="hl" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; box-sizing: border-box; max-width: 902px; touch-action: pan-x; font-size: 13.6px; font-family: var(--code-font); background-color: var(--hl_Background); margin-top: 0px; margin-bottom: 16px; overflow-wrap: normal; padding: 16px; overflow: auto; line-height: 1.45; border-radius: 6px; caret-color: rgb(36, 41, 46); color: rgb(36, 41, 46);"><code class="language-" style="box-sizing: border-box; font-size: 13.6px; font-family: var(--code-font); padding: 0px; margin: 0px; background-color: initial; border-radius: 6px; word-break: normal; white-space: pre; background-image: none; background-position: 0% 0%; background-size: auto; background-repeat: repeat; background-attachment: scroll; background-origin: padding-box; background-clip: border-box; border: 0px; display: inline; overflow: visible; line-height: inherit; overflow-wrap: normal;">xcodebuild -project QuickMD.xcodeproj -scheme QuickMD \
           -destination 'platform=macOS' test CODE_SIGNING_ALLOWED=NO
</code></pre><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; caret-color: rgb(36, 41, 46); color: rgb(36, 41, 46); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;;">Written with Claude Code.</p><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; box-sizing: border-box; margin-top: 0px; caret-color: rgb(36, 41, 46); color: rgb(36, 41, 46); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; margin-bottom: 0px !important;">Happy to split, rename, or drop the added test if you would rather keep the suite as it is</p>